### PR TITLE
:see_no_evil: Don't call close for nil.

### DIFF
--- a/lib/zabbix_sender/sender.rb
+++ b/lib/zabbix_sender/sender.rb
@@ -17,7 +17,7 @@ module ZabbixSender
         socket = TCPSocket.new(zabbix_host, zabbix_port)
         request.send(socket)
       ensure
-        socket.close
+        socket.close if socket
       end
     end
 


### PR DESCRIPTION
Hi, long time no see.

Before this change, ZabbixSender#post raise NoMethodError when connection failed.

```
> ZabbixSender.new(zabbix_host: "invalid_hostname").post("host", "key", "value")
NoMethodError: undefined method `close' for nil:NilClass
```

After this pull request, you can get original exception.

```
> ZabbixSender.new(zabbix_host: "invalid_hostname").post("host", "key", "value")
SocketError: getaddrinfo: nodename nor servname provided, or not known
```
