### PR TITLE
respect Zabbix Protocol

### DIFF
--- a/lib/zabbix_sender/request.rb
+++ b/lib/zabbix_sender/request.rb
@@ -23,7 +23,7 @@ module ZabbixSender
     end
 
     def send(socket)
-      socket.puts(encoded_data)
+      socket.write(encoded_data)
       @raw_response = socket.gets
       response
     end

--- a/lib/zabbix_sender/request.rb
+++ b/lib/zabbix_sender/request.rb
@@ -24,12 +24,14 @@ module ZabbixSender
 
     def send(socket)
       socket.write(encoded_data)
-      @raw_response = socket.gets
+      @raw_header = socket.read(HEADER.bytesize + 8)
+      datalen = @raw_header[HEADER.bytesize, 8].unpack("Q")[0]
+      @raw_response = socket.read(datalen)
       response
     end
 
     def response
-      @response ||= JSON.parse(@raw_response[13..-1])
+      @response ||= JSON.parse(@raw_response)
     end
 
     private

--- a/lib/zabbix_sender/sender.rb
+++ b/lib/zabbix_sender/sender.rb
@@ -20,11 +20,5 @@ module ZabbixSender
         socket.close if socket
       end
     end
-
-    private
-
-    def decode(raw_data)
-      JSON.parse(raw_data[13..-1])
-    end
   end
 end


### PR DESCRIPTION
ZabbixSender::Request fail to parse response from zabbix_proxy 2.2  series, because the JSON in the response contains newline and ZabbixSender::Request#send read from the socket by #gets method.

The JSON message length should be obtained from Zabbix Heder (ref. https://www.zabbix.com/documentation/1.8/protocols).

And suppress trailing newline in the request message send to the zabbix_proxy by using #write method instead of #puts.
