### PR TITLE
Consider UTF-8 ZabbixSender::Request#data_length.

### DIFF
--- a/lib/zabbix_sender/request.rb
+++ b/lib/zabbix_sender/request.rb
@@ -51,7 +51,7 @@ module ZabbixSender
     end
 
     def data_length
-      [data.size].pack("Q").force_encoding("UTF-8")
+      [data.bytesize].pack("Q").force_encoding("UTF-8")
     end
 
     def encoded_data


### PR DESCRIPTION
The `data` with multibyte encoding String, ZabbixSender::Request#data_length return invalid data length.